### PR TITLE
Avoid NPE when missing Export-Package attribute

### DIFF
--- a/src/main/java/org/revapi/osgi/ExportPackageFilter.java
+++ b/src/main/java/org/revapi/osgi/ExportPackageFilter.java
@@ -75,8 +75,9 @@ public final class ExportPackageFilter implements ElementFilter {
             }
 
             String directive = manifest.getMainAttributes().getValue("Export-Package");
-
-            ExportPackageEntryParser.parse(directive, exportedPackages);
+            if (directive != null) {
+                ExportPackageEntryParser.parse(directive, exportedPackages);
+            }
         } catch (IOException e) {
             LOG.debug("Failed to open the archive " + archive + " as a jar.", e);
         }


### PR DESCRIPTION
When an OSGi bundle doesn't actually include an `Export-Package` attribute in it's manifest, the current plugin would throw a `NullPointerException`.

When the attribute doesn't exist, we should just avoid parsing it.