### PR TITLE
Avoid more NPEs and handle version= in export declaration

### DIFF
--- a/src/main/java/org/revapi/osgi/ExportPackageDefinition.java
+++ b/src/main/java/org/revapi/osgi/ExportPackageDefinition.java
@@ -1,19 +1,19 @@
 package org.revapi.osgi;
 
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toSet;
+import org.revapi.Element;
+import org.revapi.java.spi.JavaTypeElement;
 
+import javax.lang.model.element.Name;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import javax.lang.model.element.Name;
-import javax.lang.model.element.TypeElement;
-
-import org.revapi.Element;
-import org.revapi.java.spi.JavaTypeElement;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 
 final class ExportPackageDefinition {
     private final Set<String> packageNames;
@@ -52,7 +52,11 @@ final class ExportPackageDefinition {
         JavaTypeElement model = (JavaTypeElement) element;
         TypeElement type = model.getDeclaringElement();
 
-        Name packageName = model.getTypeEnvironment().getElementUtils().getPackageOf(type).getQualifiedName();
+        PackageElement packageOf = model.getTypeEnvironment().getElementUtils().getPackageOf(type);
+        if (packageOf == null) {
+            return false;
+        }
+        Name packageName = packageOf.getQualifiedName();
         Name className = type.getSimpleName();
 
         boolean packageMatches = packageNames.stream().anyMatch(p -> p.contentEquals(packageName));

--- a/src/main/java/org/revapi/osgi/ExportPackageEntryParser.java
+++ b/src/main/java/org/revapi/osgi/ExportPackageEntryParser.java
@@ -1,13 +1,13 @@
 package org.revapi.osgi;
 
-import static java.util.stream.Collectors.toList;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
 
 final class ExportPackageEntryParser {
     private static final Pattern COMMA = Pattern.compile(",");
@@ -97,6 +97,8 @@ final class ExportPackageEntryParser {
                         if (Character.isJavaIdentifierPart(c)) {
                             ctx.accumulate(c);
                             return PACKAGE;
+                        } else if (c == '"') {
+                            return EXPORT;
                         } else {
                             return ERROR;
                         }
@@ -303,12 +305,14 @@ final class ExportPackageEntryParser {
         static void parsePackage(String directive, Set<ExportPackageDefinition> output) {
             Context ctx = new Context(output);
             ParserState state = EXPORT;
-            for (int i = 0; i < directive.length(); ++i) {
-                char c = directive.charAt(i);
-                state = state.next(c, ctx);
-                if (state == ERROR) {
-                    throw new IllegalArgumentException("Could not parse the Export-Package directive. Errored on index "
-                            + i + " of directive:\n" + directive);
+            if (directive != null) {
+                for (int i = 0; i < directive.length(); ++i) {
+                    char c = directive.charAt(i);
+                    state = state.next(c, ctx);
+                    if (state == ERROR) {
+                        throw new IllegalArgumentException("Could not parse the Export-Package directive. Errored on index "
+                                + i + " of directive:\n" + directive);
+                    }
                 }
             }
             state.finalize(ctx);

--- a/src/main/java/org/revapi/osgi/ExportPackageEntryParser.java
+++ b/src/main/java/org/revapi/osgi/ExportPackageEntryParser.java
@@ -58,7 +58,7 @@ final class ExportPackageEntryParser {
         EXPORT {
             @Override
             protected ParserState next(char c, Context ctx) {
-                if (Character.isJavaIdentifierStart(c)) {
+                if (Character.isJavaIdentifierStart(c) || c == ',') {
                     ctx.accumulate(c);
                     return PACKAGE;
                 } else if (Character.isWhitespace(c)) {

--- a/src/test/java/org/revapi/osgi/ExportPackageEntryParserTest.java
+++ b/src/test/java/org/revapi/osgi/ExportPackageEntryParserTest.java
@@ -1,11 +1,6 @@
 package org.revapi.osgi;
 
-import static java.util.Collections.emptySet;
-import static java.util.Collections.singleton;
-import static java.util.stream.Collectors.toSet;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -13,7 +8,11 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
-import org.junit.Test;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static java.util.stream.Collectors.toSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ExportPackageEntryParserTest {
 
@@ -36,6 +35,17 @@ public class ExportPackageEntryParserTest {
             assertEquals(setOf("a.b.c", "d.e.f"), def.getPackageNames());
             assertTrue(def.getIncludes().isEmpty());
             assertTrue(def.getExcludes().isEmpty());
+        });
+    }
+
+    @Test
+    public void testParsesPackageWithVersionDirective() {
+        test("com.test.api;version=\"23.0.4\";uses:=\"com.fasterxml.jackson.annotation,com.fasterxml.jackson.databind.annotation," +
+                 "freemarker.template,javax.naming.ldap,org.springframework.ldap.core\"", exports -> {
+
+            assertEquals(4, exports.size());
+            assertEquals(exports.stream().filter((ExportPackageDefinition def)-> def.getPackageNames().contains("com.test.api")).count(), 1);
+
         });
     }
 

--- a/src/test/java/org/revapi/osgi/ExportPackageEntryParserTest.java
+++ b/src/test/java/org/revapi/osgi/ExportPackageEntryParserTest.java
@@ -50,6 +50,18 @@ public class ExportPackageEntryParserTest {
     }
 
     @Test
+    public void testParsesMultiplePackageWithVersionDirective() {
+        test("com.test.api;version=\"23.0.4\";uses:=\"com.fasterxml.jackson.annotation,com.fasterxml.jackson.databind.annotation," +
+                 "freemarker.template,javax.naming.ldap,org.springframework.ldap.core\",com.test.impl;version=\"23.0.4\";uses:=\"com.fasterxml.jackson" +
+                 ".annotation,com.fasterxml.jackson.databind.annotation,freemarker.template,javax.naming.ldap,org.springframework.ldap.core\"", exports -> {
+
+            assertEquals(5, exports.size());
+            assertEquals(exports.stream().filter((ExportPackageDefinition def)-> def.getPackageNames().contains("com.test.api")).count(), 1);
+
+        });
+    }
+
+    @Test
     public void testParsesSinglePackageWithSingleDirective() {
         test("a.b.c;include:=X*", exports -> {
             assertEquals(1, exports.size());


### PR DESCRIPTION
Patch includes more additional NPE checking/traping in the case there's no exports packages.

And updates the parser to return with an EXPORT rather than ERROR if the last character in the directive is a `"`.
